### PR TITLE
Added HTTP error output to provide visible feedback to the user

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,33 @@ pub struct Wiki {
     paths: Vec<PathBuf>,
 }
 
+fn get_http_error_as_html(status: iron::status::Status) -> (iron::mime::Mime, iron::status::Status, &'static str) {
+
+    match status {
+        status::NotFound =>
+            (ContentType::html().0, status, "
+<html>
+    <head><title>404 Not Found</title></head>
+    <body>
+        <h1>Not found</h1>
+        <p>The requested page was not found on this server.</p>
+    </body>
+</html>
+"),
+
+        status::InternalServerError => (ContentType::html().0, status, "
+<html>
+    <head><title>500 Internal server error</title></head>
+    <body>
+        <h1>Internal server error</h1>
+    </body>
+</html>
+"),
+
+        _ => (ContentType::html().0, status, "")
+    }
+}
+
 impl Wiki {
     /// Create a new `Wiki` instance
     pub fn new() -> Self {
@@ -168,18 +195,18 @@ impl Wiki {
                 }
 
                 if !path.exists() {
-                    return Ok(Response::with(status::InternalServerError));
+                    return Ok(Response::with(get_http_error_as_html(status::NotFound)));
                 }
 
                 let mut f = match File::open(path) {
                     Ok(v) => v,
-                    _ => return Ok(Response::with(status::NotFound)),
+                    _ => return Ok(Response::with(get_http_error_as_html(status::NotFound))),
                 };
 
                 let mut buffer = String::new();
                 match f.read_to_string(&mut buffer) {
                     Ok(v) => v,
-                    _ => return Ok(Response::with(status::InternalServerError)),
+                    _ => return Ok(Response::with(get_http_error_as_html(status::InternalServerError))),
                 };
 
                 /* Content type needs to be determined from the file rather than assuming html */


### PR DESCRIPTION
This adds some visible output on 404 and 500 errors using internal pre-defined html.

These internal strings are fine as a fallback but later on there should be themed and customizable versions of these. But for this we first need to think of a template engine and the overall directory structure (where should those error pages be located?).

I used a function for this to avoid stuffing the strings into the HTTP handling. Albeit this probably isn't the prettiest solution yet.