### PR TITLE
[Fixed] use of write() without checkout written amount

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ impl Wiki {
                     let output_file_path = PathBuf::from(&output_directory)
                                                .join(output_path);
                     let mut output_file = File::create(output_file_path.to_owned())?;
-                    output_file.write(to_html(&buffer).as_bytes())?;
+                    output_file.write_all(to_html(&buffer).as_bytes())?;
                     self.output_paths.push(output_path.to_path_buf());
                 },
                 None => bail!("Can not stringfy file path"),


### PR DESCRIPTION
It is not guaranteed that write() process the entire buffer. Therefore
either a check for the amount of data written must be added or write()
is replaced by write_all().

https://github.com/Manishearth/rust-clippy/wiki#unused_io_amount