### PR TITLE
[Added] multithreading for html parsing

### DIFF
--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -4,10 +4,6 @@
 
 env
 
-if [[ "$TRAVIS_RUST_VERSION" == "stable" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    cargo doc-upload;
-fi
-
 if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     cargo kcov --print-install-kcov-sh | sh;
 fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ use rayon::iter::{ParallelIterator, IntoParallelRefMutIterator};
 
 static SHA_FILE: &str = ".files.sha";
 
-#[derive(Clone)]
 pub struct InputPaths {
     path: PathBuf,
     hash: String,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -24,7 +24,15 @@ fn test_read_from_directory() {
     assert!(wiki.read_content_from_current_paths(input_dir, "html").is_ok());
     assert!(sha_file.exists());
     assert!(Path::new("html").exists());
+    println!("The following paths were found:");
+    wiki.list_current_input_paths();
+    let index_file = Path::new("html").join("index.html");
+    if index_file.exists() {
+        assert!(fs::remove_file(&index_file).is_ok());
+    }
+    assert!(wiki.create_index_tree("html").is_ok());
     let check_paths = vec![
+        "html/index.html",
         "html/code.html",
         "html/example1.html",
         "html/subsection/test_s1.html",
@@ -35,14 +43,6 @@ fn test_read_from_directory() {
     for path in check_paths {
         assert!(Path::new(path).exists());
     }
-    println!("The following paths were found:");
-    wiki.list_current_input_paths();
-    let index_file = Path::new("html").join("index.html");
-    if index_file.exists() {
-        assert!(fs::remove_file(&index_file).is_ok());
-    }
-    assert!(wiki.create_index_tree("html").is_ok());
-    assert!(index_file.exists());
 }
 
 #[test]


### PR DESCRIPTION
I added a multithreaded iterator based on the rayon crate for faster HTML parsing. I measured only 2 simple values on my laptop to evaluate. Measurement base was our example in `tests/example/example_md`.

Without MT: 23,88s, 99% CPU
With MT: 15.25s, 165% CPU

So looks like it works ^^

I think this could especially be beneficial for larger amounts of files or bigger ones.

Within this I restructured the architecture a bit and now the program does not stop, when a file could not be parsed but there is simply not output for this at all and a specific error message is shown. In my opinion this is the better choice anyway.